### PR TITLE
Add MacOS arm64 matrix

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         include:
           - { target: x86_64-apple-darwin, os: macos-latest }
+          - { target: aarch64-apple-darwin, os: macos-latest }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import {} from "npm:@bindrs/rfd";
 | Windows x32      | ❌          | ❌          | ❌          |
 | Windows arm64    | ❌          | ❌          | ❌          |
 | macOS x64        | ✅          | ✅          | ✅          |
-| macOS arm64      | ❌          | ❌          | ❌          |
+| macOS arm64      | ✅          | ✅          | ✅          |
 | Linux x64 gnu    | ✅          | ✅          | ✅          |
 | Linux x64 musl   | ❌          | ❌          | ❌          |
 | Linux arm gnu    | ❌          | ❌          | ❌          |


### PR DESCRIPTION
I search for a long time and finally find this repo, it's wonderful! Thanks! 

## Changes
I add `publish-npm.yml` a matrix for MacOS arm64. The original [rfd](https://docs.rs/rfd) support arm64 on MacOS.